### PR TITLE
fix(vscode-pull-request-github): release mode

### DIFF
--- a/.github/config.yaml
+++ b/.github/config.yaml
@@ -15,6 +15,7 @@ vscodeMarketplace:
     GitHub:
     - copilot
     - copilot-chat
+    - vscode-pull-request-github
     ms-vscode-remote:
     - remote-ssh
     rust-lang:


### PR DESCRIPTION
It always targets insiders version.